### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/grisu48/pasta
+
+go 1.15
+
+require (
+	github.com/BurntSushi/toml v0.3.1
+	github.com/akamensky/argparse v1.2.2
+)
+


### PR DESCRIPTION
For `obs-service-go_modules` we need `go.mod` file.
See [this repo](https://github.com/saschagrunert/go-modiff) for more information.