### PR TITLE
Fix wrong date handling in pasta

### DIFF
--- a/cmd/pasta/pasta.go
+++ b/cmd/pasta/pasta.go
@@ -105,6 +105,7 @@ func push(filename string, mime string, src io.Reader) (Pasta, error) {
 	if resp.StatusCode != 200 {
 		return pasta, fmt.Errorf("http status code: %d", resp.StatusCode)
 	}
+	pasta.Date = time.Now().Unix()
 	err = json.NewDecoder(resp.Body).Decode(&pasta)
 	if err != nil {
 		return pasta, err
@@ -222,7 +223,7 @@ func main() {
 		cf.RemoteHost = remote.URL
 	}
 	// Sanity checks
-	if strings.Index(cf.RemoteHost, "://") < 0 {
+	if !strings.Contains(cf.RemoteHost, "://") {
 		fmt.Fprintf(os.Stderr, "Invalid remote: %s\n", cf.RemoteHost)
 		os.Exit(1)
 	}
@@ -282,7 +283,6 @@ func main() {
 				f_name := getFilename(filename)
 				pasta, err := push(f_name, "", file)
 				pasta.Filename = f_name
-				pasta.Date = time.Now().Unix()
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "%s\n", err)
 					os.Exit(1)

--- a/test/test.sh
+++ b/test/test.sh
@@ -108,5 +108,9 @@ grep 'Cleanup[[:space:]]*=' test_config.toml
 grep 'RequestDelay[[:space:]]*=' test_config.toml
 echo "test_config.toml has been successfully created"
 
+## Check the date handling of the pasta client
+## Ensure there are no 1970 entries in ls
+! ../pasta ls | grep '1970'
+../pasta ls | grep `date +"%Y-%m-%d"`
 
 echo "All good :-)"


### PR DESCRIPTION
When reading from stdin, the date was not set resulting in 1970-01-01 being used. This commit fixes this issue and adds a test for checking if the date handling is correct.